### PR TITLE
Update the Science WG meetings schedule to 3pm UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Participate
 
-The Scientific Open Source Software (SciOSS) Working Group meets every other Thursday at 4pm UTC via [Zoom](https://zoom.us/j/4998687533).
+The Scientific Open Source Software (SciOSS) Working Group meets every other Thursday at 3pm UTC via [Zoom](https://zoom.us/j/4998687533).
 
 [Agenda and Meeting Minutes](https://docs.google.com/document/d/1w76Wd-75O5dDkCmgONG5VNsniW2kQCKiXgNIIqLYl90/edit)
 


### PR DESCRIPTION
The working group is currently meeting every other Thursday at 3pm UTC.

Signed-off-by: Inessa Pawson <inessapawson@gmail.com>